### PR TITLE
-Created HashSet<T> test coverage

### DIFF
--- a/TinyJSON/Types/ProxyArray.cs
+++ b/TinyJSON/Types/ProxyArray.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 

--- a/UnitTests/TestClassWithHashSet.cs
+++ b/UnitTests/TestClassWithHashSet.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using TinyJSON;
+
+[TestFixture]
+public class TestClassWithHashSet
+{
+    private class TestClass
+    {
+        public HashSet<bool> hashSet;
+
+        public TestClass()
+        {
+            hashSet = new HashSet<bool>
+            {
+                true,
+                false
+            };
+        }
+    }
+
+    [Test]
+    public void DumpClassWithHashSet()
+    {
+        var json = "{\"@type\":\"TestClassWithHashSet+TestClass\",\"hashSet\":[true,false]}";
+        var testClass = new TestClass();
+        Assert.AreEqual(json, JSON.Dump(testClass));
+    }
+
+    [Test]
+    public void LoadClassWithHashSet()
+    {
+        var json = "{\"@type\":\"TestClassWithHashSet+TestClass\",\"hashSet\":[true,false]}";
+        var testClass = JSON.Load(json).Make<TestClass>();
+        Assert.AreEqual(json, JSON.Dump(testClass));
+    }
+}

--- a/UnitTests/TestCollectionTypes.cs
+++ b/UnitTests/TestCollectionTypes.cs
@@ -250,6 +250,24 @@ public class TestCollectionTypes
     }
 
     [Test]
+    public void TestDumpHashSet()
+    {
+        const string ELEMENT_1 = "Element1";
+        const string ELEMENT_2 = "Element2";
+        const string ELEMENT_3 = "Element3";
+
+        var hashSet = new HashSet<string>()
+        {
+            ELEMENT_1,
+            ELEMENT_2,
+            ELEMENT_3
+        };
+
+        var json = string.Format("[\"{0}\",\"{1}\",\"{2}\"]", ELEMENT_1, ELEMENT_2, ELEMENT_3);
+        Assert.AreEqual(json, JSON.Dump(hashSet));
+    }
+
+    [Test]
     public void TestLoadHashSet()
     {
         const string ELEMENT_1 = "Element1";
@@ -263,6 +281,24 @@ public class TestCollectionTypes
         Assert.AreEqual(true, hashSet.Contains(ELEMENT_1));
         Assert.AreEqual(true, hashSet.Contains(ELEMENT_2));
         Assert.AreEqual(true, hashSet.Contains(ELEMENT_3));
+    }
+
+    [Test]
+    public void TestDumpHashSetWithEnumKeys()
+    {
+        const TestEnum ELEMENT_1 = TestEnum.Thing1;
+        const TestEnum ELEMENT_2 = TestEnum.Thing2;
+        const TestEnum ELEMENT_3 = TestEnum.Thing3;
+
+        var hashSet = new HashSet<TestEnum>()
+        {
+            ELEMENT_1,
+            ELEMENT_2,
+            ELEMENT_3
+        };
+
+        var json = string.Format("[\"{0}\",\"{1}\",\"{2}\"]", ELEMENT_1, ELEMENT_2, ELEMENT_3);
+        Assert.AreEqual(json, JSON.Dump(hashSet));
     }
 
     [Test]

--- a/UnitTests/TestCollectionTypes.cs
+++ b/UnitTests/TestCollectionTypes.cs
@@ -1,7 +1,7 @@
-using System;
-using TinyJSON;
 using NUnit.Framework;
+using System;
 using System.Collections.Generic;
+using TinyJSON;
 
 
 [TestFixture]
@@ -249,5 +249,35 @@ public class TestCollectionTypes
         Assert.AreEqual( "Item 3", dict[TestEnum.Thing3] );
     }
 
-}
+    [Test]
+    public void TestLoadHashSet()
+    {
+        const string ELEMENT_1 = "Element1";
+        const string ELEMENT_2 = "Element2";
+        const string ELEMENT_3 = "Element3";
 
+        var json = string.Format("[\"{0}\",\"{1}\",\"{2}\"]", ELEMENT_1, ELEMENT_2, ELEMENT_3);
+        var hashSet = JSON.Load(json).Make<HashSet<string>>();
+        Assert.AreNotEqual(null, hashSet);
+        Assert.AreEqual(3, hashSet.Count);
+        Assert.AreEqual(true, hashSet.Contains(ELEMENT_1));
+        Assert.AreEqual(true, hashSet.Contains(ELEMENT_2));
+        Assert.AreEqual(true, hashSet.Contains(ELEMENT_3));
+    }
+
+    [Test]
+    public void TestLoadHashSetWithEnum()
+    {
+        const int ELEMENT_1 = (int)TestEnum.Thing1;
+        const int ELEMENT_2 = (int)TestEnum.Thing2;
+        const int ELEMENT_3 = (int)TestEnum.Thing3;
+
+        var json = string.Format("[\"{0}\",\"{1}\",\"{2}\"]", ELEMENT_1, ELEMENT_2, ELEMENT_3);
+        var hashSet = JSON.Load(json).Make<HashSet<TestEnum>>();
+        Assert.AreNotEqual(null, hashSet);
+        Assert.AreEqual(3, hashSet.Count);
+        Assert.AreEqual(true, hashSet.Contains((TestEnum)ELEMENT_1));
+        Assert.AreEqual(true, hashSet.Contains((TestEnum)ELEMENT_2));
+        Assert.AreEqual(true, hashSet.Contains((TestEnum)ELEMENT_3));
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -37,6 +37,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestClassWithHashSet.cs" />
     <Compile Include="TestCombining.cs" />
     <Compile Include="TestSimpleTypes.cs" />
     <Compile Include="TestClassType.cs" />


### PR DESCRIPTION
- Added ability to encode and decode HashSets
  - Convert internals of the HashSet<T> to a List<T>
- Added test coverage for hashset support
  - Added test coverage for a class that includes a HashSet<T>
    - This was done because there is no nongeneric interface for HashSets specifically so decoding may have been an issue
      - HashSet has IEnumerable (but that's too generic)
      - No IHashSet while Dictionary and List have IDictionary and IList